### PR TITLE
Skip clickhouse user setup to enable default user and pin demo version

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # Demo App version
 IMAGE_VERSION=1.10.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
-DEMO_VERSION=latest
+DEMO_VERSION=1.10.0
 
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.102.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -735,6 +735,8 @@ services:
     ports:
       - "${CLICKHOUSE_NATIVE_PORT}:9000"
       - "${CLICKHOUSE_HTTP_PORT}:8143"
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1    
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
# Changes

This fixes the following issues by skipping clickhouse user setup and pinning demo version

- Otel collector crashes because clickhouse container disables the default user.
- The latest version of frontend proxy container also crashes due to missing envs.
