### PR TITLE
Migrate to Clickstack Helm chart

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -33,7 +33,7 @@ This section uses the [official Helm chart](https://clickhouse.com/docs/use-case
 Add the HyperDX Helm repository:
 
 ```
-helm repo add hyperdx https://hyperdxio.github.io/helm-charts
+helm repo add clickstack https://clickhouse.github.io/ClickStack-helm-charts
 helm repo update
 ```
 
@@ -42,7 +42,7 @@ helm repo update
 To deploy the ClickStack with ClickHouse included:
 
 ```
-helm install my-hyperdx hyperdx/hdx-oss-v2 --set global.storageClassName="standard-rwo" -n otel-demo
+helm install my-clickstack clickstack/clickstack --set global.storageClassName="standard-rwo" -n otel-demo
 ```
 
 You might need to adjust the storageClassName according to your Kubernetes cluster configuration. 
@@ -56,8 +56,15 @@ If you'd rather use ClickHouse Cloud, you can deploy Clickstack and [disable the
 export CLICKHOUSE_URL=<CLICKHOUSE_CLOUD_URL> # full https url
 export CLICKHOUSE_USER=<CLICKHOUSE_USER>
 export CLICKHOUSE_PASSWORD=<CLICKHOUSE_PASSWORD>
+export CLICKHOUSE_DATABASE=<CLICKHOUSE_DATABASE>
 
-helm install my-hyperdx hyperdx/hdx-oss-v2  --set clickhouse.enabled=false --set clickhouse.persistence.enabled=false --set otel.clickhouseEndpoint=${CLICKHOUSE_URL} --set clickhouse.config.users.otelUserName=${CLICKHOUSE_USER} --set clickhouse.config.users.otelUserPassword=${CLICKHOUSE_PASSWORD} --set global.storageClassName="standard-rwo" -n otel-demo
+helm install my-clickstack clickstack/clickstack --set global.storageClassName="standard-rwo" \
+  -n otel-demo --set clickhouse.enabled=false \
+  --set clickhouse.persistence.enabled=false \
+  --set otel.clickhouseEndpoint=${CLICKHOUSE_URL} \
+  --set clickhouse.config.users.otelUserName=${CLICKHOUSE_USER} \
+  --set clickhouse.config.users.otelUserPassword=${CLICKHOUSE_PASSWORD} \
+  --set otel.clickhouseDatabase=${CLICKHOUSE_DATABASE}
 ```
 
 ### Access HyperDX UI
@@ -65,16 +72,13 @@ helm install my-hyperdx hyperdx/hdx-oss-v2  --set clickhouse.enabled=false --set
 Check the pods initialization: 
 
 ```
-kubectl get pods -l "app.kubernetes.io/name=hdx-oss-v2" -n otel-demo
+kubectl get pods -l "app.kubernetes.io/name=clickstack" -n otel-demo
 ```
 
 Once the pods are correctly initialized, access the HyperDX UI using port-forward:
 
 ```
-kubectl port-forward \
-  pod/$(kubectl get pod -l app.kubernetes.io/name=hdx-oss-v2 -o jsonpath='{.items[0].metadata.name}' -n otel-demo) \
-  8080:3000 \
-  -n otel-demo
+kubectl -n otel-demo port-forward svc/my-clickstack-app 3000:3000
 ```
 
 You can then access the UI at `http://localhost:8080`

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -1133,7 +1133,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADDR
@@ -1233,7 +1233,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: AD_PORT
@@ -1332,7 +1332,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CART_PORT
@@ -1441,7 +1441,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CHECKOUT_PORT
@@ -1559,7 +1559,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CURRENCY_PORT
@@ -1654,7 +1654,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: EMAIL_PORT
@@ -1760,7 +1760,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -1819,7 +1819,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -1927,7 +1927,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADDR
@@ -2031,7 +2031,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FRONTEND_PORT
@@ -2172,7 +2172,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: ENVOY_PORT
@@ -2301,7 +2301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: IMAGE_PROVIDER_PORT
@@ -2398,7 +2398,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
@@ -2497,7 +2497,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: LOCUST_WEB_HOST
@@ -2659,7 +2659,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PAYMENT_PORT
@@ -2766,7 +2766,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PRODUCT_CATALOG_PORT
@@ -2870,7 +2870,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: QUOTE_PORT
@@ -2969,7 +2969,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: RECOMMENDATION_PORT
@@ -3072,7 +3072,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: SHIPPING_PORT
@@ -3167,7 +3167,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: my-hyperdx-hdx-oss-v2-otel-collector
+              value: my-clickstack-otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: POD_NAME


### PR DESCRIPTION
Migrate to Clickstack Helm chart. 

Use this documentation as a reference: https://clickhouse.com/docs/use-cases/observability/clickstack/deployment/helm
